### PR TITLE
Support setting tag and start period

### DIFF
--- a/src/Analytics/Posts.php
+++ b/src/Analytics/Posts.php
@@ -29,6 +29,11 @@ class Posts
     private $page;
 
     /**
+     * @var string
+     */
+    private $periodStart;
+
+    /**
      * @var int
      */
     private $limit;
@@ -37,6 +42,11 @@ class Posts
      * @var string
      */
     private $section;
+
+    /**
+     * @var string
+     */
+    private $tag;
 
     /**
      * Posts constructor.
@@ -108,6 +118,46 @@ class Posts
         return $this;
     }
 
+    /**
+     * @return string
+     */
+    public function getPeriodStart(): ?string
+    {
+        return $this->periodStart;
+    }
+
+    /**
+     * @param string $periodStart
+     *
+     * @return Posts
+     */
+    public function setPeriodStart(string $periodStart = null): self
+    {
+        $this->periodStart = $periodStart;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTag(): ?string
+    {
+        return $this->tag;
+    }
+
+    /**
+     * @param string $tag
+     *
+     * @return Posts
+     */
+    public function setTag(string $tag = null): self
+    {
+        $this->tag = $tag;
+
+        return $this;
+    }
+
     public function execute(): PromiseInterface
     {
         $options = [
@@ -130,8 +180,10 @@ class Posts
     {
         return array_filter([
             'page' => $this->getPage(),
+            'period_start' => $this->getPeriodStart(),
             'limit' => $this->getLimit(),
             'section' => $this->getSection(),
+            'tag' => $this->getTag(),
         ]);
     }
 }

--- a/src/Analytics/Posts.php
+++ b/src/Analytics/Posts.php
@@ -4,10 +4,10 @@ namespace Lullabot\Parsely\Analytics;
 
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Promise\PromiseInterface;
+use Lullabot\Parsely\Encoder\JsonEncoder;
 use Lullabot\Parsely\PostList;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
-use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;

--- a/src/Encoder/JsonEncoder.php
+++ b/src/Encoder/JsonEncoder.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Lullabot\Parsely\Encoder;
+
+use Symfony\Component\Serializer\Encoder\JsonEncoder as SymfonyJsonEncoder;
+
+/**
+ * Encoder for JSON-formatted data with NULL properties.
+ */
+class JsonEncoder extends SymfonyJsonEncoder
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function decode($data, $format, array $context = [])
+    {
+        $decoded = parent::decode($data, $format, $context);
+        $this->cleanup($decoded);
+
+        return $decoded;
+    }
+
+    /**
+     * Recursively filter an array, removing null and empty string values.
+     *
+     * @param array &$data The data to filter.
+     */
+    protected function cleanup(array &$data)
+    {
+        foreach ($data as &$value) {
+            if (\is_array($value)) {
+                $this->cleanup($value);
+            }
+        }
+
+        $data = array_filter($data, function ($value) {
+            return null !== $value;
+        });
+    }
+}

--- a/src/Post.php
+++ b/src/Post.php
@@ -303,9 +303,9 @@ class Post
     }
 
     /**
-     * @return string
+     * @return ?string
      */
-    public function getThumbUrlMedium(): string
+    public function getThumbUrlMedium(): ?string
     {
         return $this->thumbUrlMedium;
     }
@@ -315,7 +315,7 @@ class Post
      *
      * @return Post
      */
-    public function setThumbUrlMedium(string $thumbUrlMedium): self
+    public function setThumbUrlMedium(string $thumbUrlMedium = null): self
     {
         $this->thumbUrlMedium = $thumbUrlMedium;
 


### PR DESCRIPTION
* Supports setting a start time from https://www.parse.ly/help/api/analytics/
* Fixes that empty values from parse.ly are returned as null _and_ as empty strings. For example, I found one post that had an empty string for `image_url`, but null for the `thumbnail_url_medium` property. This fails out for the PhpDocExtractor, so we filter out all null values on decode.