### PR TITLE
Support merging multiple lists of posts

### DIFF
--- a/src/PostList.php
+++ b/src/PostList.php
@@ -8,7 +8,7 @@ namespace Lullabot\Parsely;
  * @todo Do all lists of any object have the same format? If so, this could
  *   become just 'List'.
  */
-class PostList implements \ArrayAccess, \Countable
+class PostList implements \IteratorAggregate, \ArrayAccess, \Countable
 {
     /**
      * @var \Lullabot\Parsely\Post[]
@@ -92,5 +92,12 @@ class PostList implements \ArrayAccess, \Countable
         $new->setData($merged);
 
         return $new;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator() {
+        return new \ArrayIterator($this->getData());
     }
 }

--- a/src/PostList.php
+++ b/src/PostList.php
@@ -15,6 +15,11 @@ class PostList implements \ArrayAccess, \Countable
      */
     private $data;
 
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
     /**
      * @param \Lullabot\Parsely\Post[] $data
      */
@@ -46,5 +51,46 @@ class PostList implements \ArrayAccess, \Countable
     public function count()
     {
         return \count($this->data);
+    }
+
+    /**
+     * Merge this list of posts with other lists of posts.
+     *
+     * A new post list is returned, with:
+     *  - Duplicates removed, based on post title.
+     *  - Sorted by the number of hits in descending order.
+     *
+     * @param self ...$others The other post lists to merge.
+     *
+     * @return \Lullabot\Parsely\PostList
+     */
+    public function merge(self ...$others): PostList
+    {
+        $merged = $this->getData();
+        foreach ($others as $other) {
+            $merged = array_merge($merged, $other->getData());
+        }
+
+        // Remove duplicate results from the other list, based on title.
+        $titles = [];
+        $merged = array_filter($merged, function (Post $post) use (&$titles) {
+            if (\in_array($post->getTitle(), $titles)) {
+                return false;
+            }
+
+            $titles[] = $post->getTitle();
+
+            return true;
+        });
+
+        // Sort by the number of hits.
+        usort($merged, function (Post $a, Post $b) {
+            return $a->getHits() > $b->getHits() ? -1 : 1;
+        });
+
+        $new = new self();
+        $new->setData($merged);
+
+        return $new;
     }
 }

--- a/src/PostList.php
+++ b/src/PostList.php
@@ -94,6 +94,14 @@ class PostList implements \IteratorAggregate, \ArrayAccess, \Countable
         return $new;
     }
 
+    public function slice(int $offset, int $length = null, bool $perserveKeys = false): self
+    {
+        $slice = new self();
+        $slice->setData(\array_slice($this->getData(), $offset, $length, $perserveKeys));
+
+        return $slice;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/PostList.php
+++ b/src/PostList.php
@@ -97,7 +97,8 @@ class PostList implements \IteratorAggregate, \ArrayAccess, \Countable
     /**
      * {@inheritdoc}
      */
-    public function getIterator() {
+    public function getIterator()
+    {
         return new \ArrayIterator($this->getData());
     }
 }

--- a/src/PostList.php
+++ b/src/PostList.php
@@ -64,7 +64,7 @@ class PostList implements \ArrayAccess, \Countable
      *
      * @return \Lullabot\Parsely\PostList
      */
-    public function merge(self ...$others): PostList
+    public function merge(self ...$others): self
     {
         $merged = $this->getData();
         foreach ($others as $other) {

--- a/src/PostList.php
+++ b/src/PostList.php
@@ -54,21 +54,21 @@ class PostList implements \ArrayAccess, \Countable
     }
 
     /**
-     * Merge this list of posts with other lists of posts.
+     * Merge lists of posts.
      *
      * A new post list is returned, with:
      *  - Duplicates removed, based on post title.
      *  - Sorted by the number of hits in descending order.
      *
-     * @param self ...$others The other post lists to merge.
+     * @param self ...$lists The other post lists to merge.
      *
      * @return \Lullabot\Parsely\PostList
      */
-    public function merge(self ...$others): self
+    public static function merge(self ...$lists): self
     {
-        $merged = $this->getData();
-        foreach ($others as $other) {
-            $merged = array_merge($merged, $other->getData());
+        $merged = [];
+        foreach ($lists as $list) {
+            $merged = array_merge($merged, $list->getData());
         }
 
         // Remove duplicate results from the other list, based on title.

--- a/tests/src/Unit/PostListTest.php
+++ b/tests/src/Unit/PostListTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Lullabot\Parsely\Tests\Unit;
+
+use Lullabot\Parsely\Post;
+use Lullabot\Parsely\PostList;
+use PHPUnit\Framework\TestCase;
+
+class PostListTest extends TestCase {
+
+    public function testMerge()
+    {
+        // Four mock posts to use in different lists.
+        $one = $this->getPost('One post', 3);
+        $two = $this->getPost('Two post', 4);
+        $three = $this->getPost('Three post', 2);
+        $four = $this->getPost('Four post', 10);
+
+        $firstList = new PostList();
+        $firstList->setData([
+            $one,
+            $two,
+        ]);
+
+        // "two" is a duplicate post so it should be removed.
+        $secondList = new PostList();
+        $secondList->setData([
+            $two,
+            $three,
+        ]);
+
+        // "two" and "three" will be removed, and "four" will be sorted to the
+        // top.
+        $thirdList = new PostList();
+        $thirdList->setData([
+            $two,
+            $three,
+            $four,
+        ]);
+
+        $merged = $firstList->merge($secondList, $thirdList);
+
+        $expected = [
+            $four,
+            $two,
+            $one,
+            $three,
+        ];
+        $this->assertEquals($expected, $merged->getData());
+    }
+
+    private function getPost(string $title, int $hits): Post
+    {
+        $post = new Post();
+        $post->setTitle($title);
+        $post->setHits($hits);
+        return $post;
+    }
+}

--- a/tests/src/Unit/PostListTest.php
+++ b/tests/src/Unit/PostListTest.php
@@ -38,7 +38,7 @@ class PostListTest extends TestCase
             $four,
         ]);
 
-        $merged = $firstList->merge($secondList, $thirdList);
+        $merged = PostList::merge($firstList, $secondList, $thirdList);
 
         $expected = [
             $four,

--- a/tests/src/Unit/PostListTest.php
+++ b/tests/src/Unit/PostListTest.php
@@ -6,8 +6,8 @@ use Lullabot\Parsely\Post;
 use Lullabot\Parsely\PostList;
 use PHPUnit\Framework\TestCase;
 
-class PostListTest extends TestCase {
-
+class PostListTest extends TestCase
+{
     public function testMerge()
     {
         // Four mock posts to use in different lists.
@@ -54,6 +54,7 @@ class PostListTest extends TestCase {
         $post = new Post();
         $post->setTitle($title);
         $post->setHits($hits);
+
         return $post;
     }
 }

--- a/tests/src/Unit/PostListTest.php
+++ b/tests/src/Unit/PostListTest.php
@@ -49,6 +49,24 @@ class PostListTest extends TestCase
         $this->assertEquals($expected, $merged->getData());
     }
 
+    /**
+     * Test that a single list is "merged" properly.
+     */
+    public function testOneMerge()
+    {
+        $one = $this->getPost('One post', 4);
+        $two = $this->getPost('Two post', 3);
+
+        $firstList = new PostList();
+        $firstList->setData([
+            $one,
+            $two,
+        ]);
+
+        $merged = PostList::merge($firstList);
+        $this->assertEquals($firstList->getData(), $merged->getData());
+    }
+
     private function getPost(string $title, int $hits): Post
     {
         $post = new Post();


### PR DESCRIPTION
Parsely's API only supports querying for one section or tag at a time. This `merge()` method allows for a variable number of lists to be merged together, removing duplicates and sorting by hits.