### PR TITLE
BO-572 Add support for multiple sections

### DIFF
--- a/src/Analytics/Posts.php
+++ b/src/Analytics/Posts.php
@@ -98,7 +98,7 @@ class Posts
         return $this;
     }
 
-    public function getSections(): array
+    public function getSections(): ?array
     {
         return $this->sections;
     }
@@ -177,4 +177,5 @@ class Posts
             'tag' => $this->getTag(),
         ]);
     }
+
 }

--- a/src/Analytics/Posts.php
+++ b/src/Analytics/Posts.php
@@ -39,9 +39,9 @@ class Posts
     private $limit;
 
     /**
-     * @var string
+     * @var array
      */
-    private $section;
+    private $sections;
 
     /**
      * @var string
@@ -98,26 +98,17 @@ class Posts
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getSection(): ?string
+    public function getSections(): array
     {
-        return $this->section;
+        return $this->sections;
     }
 
-    /**
-     * @param string $section
-     *
-     * @return Posts
-     */
-    public function setSection(string $section): self
+    public function setSections(array $sections): self
     {
-        $this->section = $section;
+        $this->sections = $sections;
 
         return $this;
     }
-
     /**
      * @return string
      */
@@ -182,7 +173,7 @@ class Posts
             'page' => $this->getPage(),
             'period_start' => $this->getPeriodStart(),
             'limit' => $this->getLimit(),
-            'section' => $this->getSection(),
+            'section' => $this->getSections(),
             'tag' => $this->getTag(),
         ]);
     }

--- a/src/Analytics/Posts.php
+++ b/src/Analytics/Posts.php
@@ -109,6 +109,7 @@ class Posts
 
         return $this;
     }
+
     /**
      * @return string
      */
@@ -177,5 +178,4 @@ class Posts
             'tag' => $this->getTag(),
         ]);
     }
-
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -5,6 +5,7 @@ namespace Lullabot\Parsely;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\HandlerStack;
 use Psr\Http\Message\RequestInterface;
+use function GuzzleHttp\Psr7\build_query;
 
 class Client implements ClientInterface
 {
@@ -76,7 +77,7 @@ class Client implements ClientInterface
      */
     public function request($method = 'GET', $url = null, array $options = [])
     {
-        return $this->client->request($method, $url, $this->mergeAuth($options));
+        return $this->client->request($method, $url, $this->flattenQuery($this->mergeAuth($options)));
     }
 
     /**
@@ -84,7 +85,7 @@ class Client implements ClientInterface
      */
     public function send(RequestInterface $request, array $options = [])
     {
-        return $this->client->send($request, $this->mergeAuth($options));
+        return $this->client->send($request, $this->flattenQuery($this->mergeAuth($options)));
     }
 
     /**
@@ -92,7 +93,7 @@ class Client implements ClientInterface
      */
     public function sendAsync(RequestInterface $request, array $options = [])
     {
-        return $this->client->sendAsync($request, $this->mergeAuth($options));
+        return $this->client->sendAsync($request, $this->flattenQuery($this->mergeAuth($options)));
     }
 
     /**
@@ -100,7 +101,7 @@ class Client implements ClientInterface
      */
     public function requestAsync($method, $uri, array $options = [])
     {
-        return $this->client->requestAsync($method, $uri, $this->mergeAuth($options));
+        return $this->client->requestAsync($method, $uri, $this->flattenQuery($this->mergeAuth($options)));
     }
 
     /**
@@ -128,6 +129,26 @@ class Client implements ClientInterface
             'secret' => $this->secret,
         ];
 
+        return $options;
+    }
+
+    /**
+     * Flatten the query params to string using GuzzleHttp\Psr7\build_query.
+     *
+     * Parse.ly API wants the duplicate aggregator implementation where to
+     * supply multiple values of the same key, you just name the key more than
+     * once. Leaving it to Guzzle to turn an array of query params into a string
+     * uses the http_build_query function. That uses PHP's array notation which
+     * the Parse.ly API doesn't handle.
+     *
+     * @param array $options The array of request options.
+     *
+     * @return array The updated request options.
+     */
+    private function flattenQuery(array $options): array {
+        if (isset($options['query'])) {
+            $options['query'] = build_query($options['query']);
+        }
         return $options;
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -150,6 +150,7 @@ class Client implements ClientInterface
         if (isset($options['query'])) {
             $options['query'] = build_query($options['query']);
         }
+
         return $options;
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -145,7 +145,8 @@ class Client implements ClientInterface
      *
      * @return array The updated request options.
      */
-    private function flattenQuery(array $options): array {
+    private function flattenQuery(array $options): array
+    {
         if (isset($options['query'])) {
             $options['query'] = build_query($options['query']);
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -135,11 +135,13 @@ class Client implements ClientInterface
     /**
      * Flatten the query params to string using GuzzleHttp\Psr7\build_query.
      *
-     * Parse.ly API wants the duplicate aggregator implementation where to
-     * supply multiple values of the same key, you just name the key more than
-     * once. Leaving it to Guzzle to turn an array of query params into a string
-     * uses the http_build_query function. That uses PHP's array notation which
-     * the Parse.ly API doesn't handle.
+     * To express multiple values for a single key, Parse.ly's API needs each
+     * value assigned the same key name. Unlike how PHP deals with this
+     * using square brackets at the end of the key name. Leaving it to Guzzle to
+     * turn an array of query params into a string uses the http_build_query
+     * function, which uses the square brackets. Here we make sure multiple
+     * values are sent correctly to Parse.ly by using
+     * \GuzzleHttp\Psr7\build_query.
      *
      * @param array $options The array of request options.
      *


### PR DESCRIPTION
From speaking with Parse.ly support, I discovered that the `section` query string parameter accepts multiple values. This makes querying for posts much simpler as we no longer have to make a API call per section that we want to include together in a list.