### PR TITLE
fix: uninitialized logger causes fatal error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 phpunit.xml
 build
 /.idea/
+node_modules

--- a/src/Analytics/Posts.php
+++ b/src/Analytics/Posts.php
@@ -173,7 +173,9 @@ class Posts
         $onRejected = function (GuzzleException $exception) {
             // If there is an exception log it and continue with an empty
             // post list.
-            $this->logger->error($exception->getMessage());
+            if ($this->logger) {
+                $this->logger->error($exception->getMessage());
+            }
             return new PostList();
         };
         return $this->client


### PR DESCRIPTION
This adds a guard clause to avoid calling a method on null.