### PR TITLE
fix: uninitialized logger causes fatal error

### DIFF
--- a/src/Analytics/Posts.php
+++ b/src/Analytics/Posts.php
@@ -167,8 +167,9 @@ class Posts
         $onRejected = function (GuzzleException $exception) {
             // If there is an exception log it and continue with an empty
             // post list.
-            $this->logger->error($exception->getMessage());
-
+            if ($this->logger) {
+                $this->logger->error($exception->getMessage());
+            }
             return new PostList();
         };
 

--- a/src/Analytics/Posts.php
+++ b/src/Analytics/Posts.php
@@ -170,6 +170,7 @@ class Posts
             if ($this->logger) {
                 $this->logger->error($exception->getMessage());
             }
+
             return new PostList();
         };
 


### PR DESCRIPTION
This adds a guard clause to avoid calling a method on null.